### PR TITLE
bugfix: fastq not recognized

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -878,7 +878,7 @@ int main(int argc, char **argv)
 	string sequence;
 	size_t seqLength;
 	size_t kmersize;
-        string inputFileName;
+	string inputFileName;
     string genome_type = "linear";
     bool circular_genome = false;
 	bool build_only = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -878,7 +878,6 @@ int main(int argc, char **argv)
 	string sequence;
 	size_t seqLength;
 	size_t kmersize;
-	string inputFileName;
     string genome_type = "linear";
     bool circular_genome = false;
 	bool build_only = false;
@@ -919,9 +918,11 @@ int main(int argc, char **argv)
 
 	optparse::Values& options = parser.parse_args(argc, argv);
 
-	inputFileName = (string) options.get("i");
-	input_from_reads = (inputFileName.substr(inputFileName.find_last_of(".") + 1) == "fastq") ? true : false;
-	input_from_reads = (inputFileName.substr(inputFileName.find_last_of(".") + 1) == "FASTQ") ? true : false;
+        {
+	  string inputFileName = (string) options.get("i");
+          string ft = inputFileName.substr(inputFileName.find_last_of(".") + 1);
+          input_from_reads = bool(ft == "fastq" || ft == "FASTQ" || ft == "fq" || ft == "FQ");
+        }
 
 	kmersize = (size_t) options.get("k");
 	abundance = (int) options.get("a");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -878,6 +878,7 @@ int main(int argc, char **argv)
 	string sequence;
 	size_t seqLength;
 	size_t kmersize;
+        string inputFileName;
     string genome_type = "linear";
     bool circular_genome = false;
 	bool build_only = false;
@@ -918,8 +919,8 @@ int main(int argc, char **argv)
 
 	optparse::Values& options = parser.parse_args(argc, argv);
 
+        inputFileName = (string) options.get("i");
         {
-	  string inputFileName = (string) options.get("i");
           string ft = inputFileName.substr(inputFileName.find_last_of(".") + 1);
           input_from_reads = bool(ft == "fastq" || ft == "FASTQ" || ft == "fq" || ft == "FQ");
         }


### PR DESCRIPTION
The second assignment overwrites the first one. Extended to also recognize .fq
